### PR TITLE
4.4.1 fix equals

### DIFF
--- a/in-memory-hashmap/4.4.1./README.md
+++ b/in-memory-hashmap/4.4.1./README.md
@@ -46,7 +46,10 @@
   ```
   @Override
   public boolean equals(Object obj) {
-    return name.equals(obj);
+    if (obj == null) return false;
+    if (obj.getClass() != getClass()) return false;
+    Product other = (Product) obj;
+    return name.equals(other.name);
   }
   
   @Override


### PR DESCRIPTION
если мы переопределяем equals чтобы сравнивать с другими объектами (а мы это собираемся делать в hashset/hashmap) то name.equals(obj) никогда не будет true